### PR TITLE
Extend warning for multiple coverage options

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
 	name='vcf2cytosure',
-	version='0.6.0',
+	version='0.6.1',
 	author='Marcel Martin',
 	author_email='marcel.martin@scilifelab.se',
 	maintainer='Daniel Nilsson',

--- a/vcf2cytosure.py
+++ b/vcf2cytosure.py
@@ -16,7 +16,7 @@ from cyvcf2 import VCF
 
 from constants import *
 
-__version__ = '0.6.0'
+__version__ = '0.6.1'
 
 logger = logging.getLogger(__name__)
 
@@ -536,9 +536,10 @@ def main():
 
 	logger.info('vcf2cytosure %s', __version__)
 
-	if args.coverage and args.snv:
-		print ("--coverage and --snv cannot be combined")
+	if (args.coverage and args.cn) or (args.coverage and args.snv) or (args.snv and args.cn):
+		print ("Choose one of --coverage, --snv and --cn. They cannot be combined.")
 		quit()
+
 
 	if not args.out:
 		args.out=".".join(args.vcf.split(".")[0:len(args.vcf.split("."))-1])+".cgh"


### PR DESCRIPTION
Just a small touch to the cli; warn and exit if mutually exclusive coverage options are given.