### PR TITLE
v0.8 - continued: add Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 ## [0.8]
 - Changed coverage probe height calculation to a log2-ratio
 - Aberration `gain` is no longer set to `true` for deletions (giving "loss" in vcf2cytosure)
+- Changed coverage average calculation to also exclude 0-coverage bins. Note that N-sequence bins already get no probes.
+- Add Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+###########
+# BUILDER #
+###########
+FROM clinicalgenomics/python3.8-venv:1.0
+
+ENV PATH="/venv/bin:$PATH"
+
+WORKDIR /app
+
+RUN apt-get update && \
+     apt-get -y upgrade && \
+     apt-get -y install -y --no-install-recommends gcc && \
+     apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
+
+# reqs
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+LABEL about.home="https://github.com/NBISweden/vcf2cytosure"
+LABEL about.documentation="https://github.com/NBISweden/vcf2cytosure/blob/master/README.md"
+LABEL about.tags="WGS,WES,Rare diseases,VCF,SV,Coverage,Structural variation,CNV"
+LABEL about.license="MIT License (MIT)"
+
+# Do not upgrade to the latest pip version to ensure more reproducible builds
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PATH="/venv/bin:$PATH"
+RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+
+COPY . /app
+
+# Install only vcf2cytosure
+RUN pip install --no-cache-dir --editable .
+
+WORKDIR /data/


### PR DESCRIPTION
Just a Dockerfile. Exporting the results to https://hub.docker.com/repository/docker/danielknilsson/vcf2cytosure for today; we can think about how to handle the automation. Perhaps time to fork into Clinical-Genomics and use that setup. 🧐 