### PR TITLE
Remove exclude list prefix, deprecate blacklist option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 - Lint and format code with ruff, add an action (#76)
 - Keep a changelog action (#76)
 - Run smoke test action on pull requests (#76)
-- Trim `chr` prefix from blacklist file (#77)
-- Provide an alias exclusionlist for blacklist, being deprecated (#77)
+- Trim `chr` prefix from excludelist file (#77)
+- Provide an excludelist option, alias blacklist being deprecated (#77)
 
 ## [0.9.3]
 - Update release automation build environment (#67)
@@ -15,7 +15,7 @@
 - Remove any chr prefix from input chromosome contig name (#65)
 
 ## [0.9]
-- Blacklist (excluded regions list) also hides probes
+- excludelist (excluded regions list) also hides probes
 
 ## [0.8]
 - Changed coverage probe height calculation to a log2-ratio

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Lint and format code with ruff, add an action (#76)
 - Keep a changelog action (#76)
 - Run smoke test action on pull requests (#76)
+- Trim `chr` prefix from blacklist file (#77)
+- Provide an alias exclusionlist for blacklist, being deprecated (#77)
 
 ## [0.9.3]
 - Update release automation build environment (#67)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ The binning of the input coverage file may be controlled using the --bins parame
 Here 50 coverage bins will be pooled into one probe. The number of probes affect the amount of detail and resolution in the analysis.
 A large number of probes will make cytosure sluggish.
 
+It is beneficial to the analyst to have the export ignore variants in noisy genomic regions. Consider using e.g. the ENCODE problematic regions
+exclude file or similar to avoid an excess of calls in these regions - unless your pipeline already suppresses such calls by other means.
+
+    vcf2cytosure --vcf <input.vcf> --out <output.cgh> --excludelist hg38.encode.problematic_regions.v2.bed --sex <male|female> --size 30000 --genome 38 --coverage <coverage_bed> 
+
 ## Structural variants
 Structural variant (SV) types DEL, DUP, TDUP, IDUP, INV, and INS are supported.
 For each SVs, at least three probes are generated. If the SV is large enough,

--- a/vcf2cytosure/vcf2cytosure.py
+++ b/vcf2cytosure/vcf2cytosure.py
@@ -640,9 +640,9 @@ def main():
     group.add_argument("--out", help="output file (default = the prefix of the input vcf)")
 
     group.add_argument(
-        "--blacklist",
         "--excludelist",
-        help="Exclude list bed format file to exclude completely contained variants.",
+        "--blacklist",
+        help="Exclude list bed format file to exclude completely contained variants (deprecated alias: --blacklist).",
     )
 
     group.add_argument(

--- a/vcf2cytosure/vcf2cytosure.py
+++ b/vcf2cytosure/vcf2cytosure.py
@@ -28,7 +28,7 @@ def remove_prefix(text, prefix):
         return text[len(prefix) :]
     return text
 
-    
+
 def events(variants, CONTIG_LENGTHS):
     """Iterate over variants and yield Events"""
 
@@ -640,7 +640,8 @@ def main():
     group.add_argument("--out", help="output file (default = the prefix of the input vcf)")
 
     group.add_argument(
-        "--blacklist", "--excludelist",
+        "--blacklist",
+        "--excludelist",
         help="Exclude list bed format file to exclude completely contained variants.",
     )
 

--- a/vcf2cytosure/vcf2cytosure.py
+++ b/vcf2cytosure/vcf2cytosure.py
@@ -28,7 +28,7 @@ def remove_prefix(text, prefix):
         return text[len(prefix) :]
     return text
 
-
+    
 def events(variants, CONTIG_LENGTHS):
     """Iterate over variants and yield Events"""
 
@@ -525,7 +525,8 @@ class BlacklistRecord:
     __slots__ = ("chrom", "end", "start")
 
     def __init__(self, chrom, start, end):
-        self.chrom = chrom
+
+        self.chrom = remove_prefix(chrom, "chr")
         self.start = start
         self.end = end
 
@@ -639,8 +640,8 @@ def main():
     group.add_argument("--out", help="output file (default = the prefix of the input vcf)")
 
     group.add_argument(
-        "--blacklist",
-        help="Blacklist bed format file to exclude completely contained variants.",
+        "--blacklist", "--excludelist",
+        help="Exclude list bed format file to exclude completely contained variants.",
     )
 
     group.add_argument(

--- a/vcf2cytosure/vcf2cytosure.py
+++ b/vcf2cytosure/vcf2cytosure.py
@@ -434,7 +434,7 @@ def subtract_intervals(records, intervals):
             yield record
 
 
-def add_coverage_probes(probes, path, args, CONTIG_LENGTHS, N_INTERVALS, blacklist):
+def add_coverage_probes(probes, path, args, CONTIG_LENGTHS, N_INTERVALS, excludelist):
     """
     probes -- <probes> element
     path -- path to tab-separated file with coverages
@@ -459,7 +459,7 @@ def add_coverage_probes(probes, path, args, CONTIG_LENGTHS, N_INTERVALS, blackli
 
         n_intervals = N_INTERVALS[chromosome]
         for record in subtract_intervals(bin_coverages(records, args.bins), n_intervals):
-            if contained_by_blacklist(record, blacklist):
+            if contained_by_excludelist(record, excludelist):
                 continue
 
             if not args.cn:
@@ -521,7 +521,7 @@ def variant_filter(
         yield variant
 
 
-class BlacklistRecord:
+class ExcludelistRecord:
     __slots__ = ("chrom", "end", "start")
 
     def __init__(self, chrom, start, end):
@@ -531,8 +531,8 @@ class BlacklistRecord:
         self.end = end
 
 
-# read Blacklist
-def read_blacklist(path):
+# read excludelist
+def read_excludelist(path):
     with open(path) as f:
         for line in f:
             if line.startswith("#"):
@@ -543,13 +543,13 @@ def read_blacklist(path):
             end = content[2]
             start = int(start)
             end = int(end)
-            yield BlacklistRecord(chrom, start, end)
+            yield ExcludelistRecord(chrom, start, end)
 
 
-def contained_by_blacklist(event, blacklist):
+def contained_by_excludelist(event, excludelist):
     return any(
         event.chrom == br.chrom and (event.start >= br.start and event.end <= br.end)
-        for br in blacklist
+        for br in excludelist
     )
 
 
@@ -641,8 +641,8 @@ def main():
 
     group.add_argument(
         "--excludelist",
-        "--blacklist",
-        help="Exclude list bed format file to exclude completely contained variants (deprecated alias: --blacklist).",
+        "--excludelist",
+        help="Exclude list bed format file to exclude completely contained variants (deprecated alias: --excludelist).",
     )
 
     group.add_argument(
@@ -702,9 +702,9 @@ def main():
     probes = tree.xpath("/data/cgh/probes")[0]
     submission = tree.xpath("/data/cgh/submission")[0]
 
-    blacklist = []
-    if args.blacklist:
-        blacklist = [r for r in read_blacklist(args.blacklist) if r.chrom in CONTIG_LENGTHS]
+    excludelist = []
+    if args.excludelist:
+        excludelist = [r for r in read_excludelist(args.excludelist) if r.chrom in CONTIG_LENGTHS]
 
     chr_intervals = defaultdict(list)
     if args.do_filtering:
@@ -736,8 +736,8 @@ def main():
             and not event.end
             or event.type in ("INV", "INS", "BND", "SGL", "TRA")
             and (abs(event.start - event.end) > args.maxbnd)
-            or args.blacklist
-            and contained_by_blacklist(event, blacklist)
+            or args.excludelist
+            and contained_by_excludelist(event, excludelist)
         ):
             continue
 
@@ -758,7 +758,7 @@ def main():
             make_probe(probes, event.chrom, pos, pos + 60, height, event.type)
         n += 1
     if args.coverage or args.snv or args.cn:
-        add_coverage_probes(probes, args.coverage, args, CONTIG_LENGTHS, N_INTERVALS, blacklist)
+        add_coverage_probes(probes, args.coverage, args, CONTIG_LENGTHS, N_INTERVALS, excludelist)
 
     else:
         add_probes_between_events(probes, chr_intervals, CONTIG_LENGTHS)

--- a/vcf2cytosure/vcf2cytosure.py
+++ b/vcf2cytosure/vcf2cytosure.py
@@ -641,8 +641,8 @@ def main():
 
     group.add_argument(
         "--excludelist",
-        "--excludelist",
-        help="Exclude list bed format file to exclude completely contained variants (deprecated alias: --excludelist).",
+        "--blacklist",
+        help="Exclude list bed format file to exclude completely contained variants (deprecated alias: --blacklist).",
     )
 
     group.add_argument(


### PR DESCRIPTION
- **Fix #75 - trim chr from exclude list.**
-  **Fix #72 - alias excludelist for blacklist**
- ruff
- Add a little bit of docs
- Internally substitute exclude list for variable names and classes


Tested on hasta, same result when using a pre-trimmed exclude list and one with prefixes left in. Also the option alias works. 
```
[daniel.nilsson@hasta-login:cytosure] [D_vcf2cytosure_DN] $ vcf2cytosure --vcf 2026-26929-07.vcf --maxbnd 30000 --blacklist /home/proj/stage/rare-disease/gens-tracks-hg38/hg38-blacklist.v2.bed --out ~/tmp/2026-26029-07.bl.dn.cgh --sex male --size 30000 --genome 38 --coverage ACC21378A1_cov.bed
INFO: vcf2cytosure 0.9.3
INFO: Reading 'ACC21378A1_cov.bed' ...
INFO: Mean coverage excluding 0 values is 34.77
INFO: Added 283550 coverage probes
INFO: Wrote 209 variants to CGH
[daniel.nilsson@hasta-login:cytosure] [D_vcf2cytosure_DN] $ vcf2cytosure --vcf 2026-26929-07.vcf --maxbnd 30000 --excludelist hg38-blacklist.v2.bed --out ~/tmp/2026-26029-07.bl_prefix.dn.cgh --sex male --size 30000 --genome 38 --coverage ACC21378A1_cov.bed
INFO: vcf2cytosure 0.9.3
INFO: Reading 'ACC21378A1_cov.bed' ...
INFO: Mean coverage excluding 0 values is 34.77
INFO: Added 283550 coverage probes
INFO: Wrote 209 variants to CGH
[daniel.nilsson@hasta-login:cytosure] [D_vcf2cytosure_DN] $ less hg38-blacklist.v2.bed
[daniel.nilsson@hasta-login:cytosure] [D_vcf2cytosure_DN] $ head hg38-blacklist.v2.bed
chr10	0	45700	Low Mappability
chr10	38481300	38596500	High Signal Region
chr10	38782600	38967900	High Signal Region
```
